### PR TITLE
Add Recurrent Vision-and-Language BERT paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ If you find this repository useful, please consider [citing](#citation) and STAR
 
  * "The Unsurprising Effectiveness of Pre-Trained Vision Models for Control", *ICML, Mar 2022*. [[Paper](https://arxiv.org/abs/2203.03580)] [[Pytorch Code](https://github.com/sparisi/pvr_habitat)] [[Website](https://sites.google.com/view/pvr-control)]
 
- * **Recurrent VLN-BERT**: "A Recurrent Vision-and-Language BERT for Navigation", *CVPR, Jun 2021* [[Paper](https://arxiv.org/abs/2004.14973)] [[Pytorch Code](https://github.com/YicongHong/Recurrent-VLN-BERT)]
-
  * **CoW**: "CLIP on Wheels: Zero-Shot Object Navigation as Object Localization and Exploration", *arXiv, Mar 2022*. [[Paper](https://arxiv.org/abs/2203.10421)] 
+ 
+ * **Recurrent VLN-BERT**: "A Recurrent Vision-and-Language BERT for Navigation", *CVPR, Jun 2021* [[Paper](https://arxiv.org/abs/2004.14973)] [[Pytorch Code](https://github.com/YicongHong/Recurrent-VLN-BERT)]
  
  * **VLN-BERT**: "Improving Vision-and-Language Navigation with Image-Text Pairs from the Web", *ECCV, Apr 2020* [[Paper](https://arxiv.org/abs/2004.14973)] [[Pytorch Code](https://github.com/arjunmajum/vln-bert)]
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ If you find this repository useful, please consider [citing](#citation) and STAR
 
  * **CoW**: "CLIP on Wheels: Zero-Shot Object Navigation as Object Localization and Exploration", *arXiv, Mar 2022*. [[Paper](https://arxiv.org/abs/2203.10421)] 
  
- * **Recurrent VLN-BERT**: "A Recurrent Vision-and-Language BERT for Navigation", *CVPR, Jun 2021* [[Paper](https://arxiv.org/abs/2004.14973)] [[Pytorch Code](https://github.com/YicongHong/Recurrent-VLN-BERT)]
+ * **Recurrent VLN-BERT**: "A Recurrent Vision-and-Language BERT for Navigation", *CVPR, Jun 2021* [[Paper](https://arxiv.org/abs/2011.13922)] [[Pytorch Code](https://github.com/YicongHong/Recurrent-VLN-BERT)]
  
  * **VLN-BERT**: "Improving Vision-and-Language Navigation with Image-Text Pairs from the Web", *ECCV, Apr 2020* [[Paper](https://arxiv.org/abs/2004.14973)] [[Pytorch Code](https://github.com/arjunmajum/vln-bert)]
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ If you find this repository useful, please consider [citing](#citation) and STAR
 
  * "The Unsurprising Effectiveness of Pre-Trained Vision Models for Control", *ICML, Mar 2022*. [[Paper](https://arxiv.org/abs/2203.03580)] [[Pytorch Code](https://github.com/sparisi/pvr_habitat)] [[Website](https://sites.google.com/view/pvr-control)]
 
+ * **Recurrent VLN-BERT**: "A Recurrent Vision-and-Language BERT for Navigation", *CVPR, Jun 2021* [[Paper](https://arxiv.org/abs/2004.14973)] [[Pytorch Code](https://github.com/YicongHong/Recurrent-VLN-BERT)]
+
  * **CoW**: "CLIP on Wheels: Zero-Shot Object Navigation as Object Localization and Exploration", *arXiv, Mar 2022*. [[Paper](https://arxiv.org/abs/2203.10421)] 
  
  * **VLN-BERT**: "Improving Vision-and-Language Navigation with Image-Text Pairs from the Web", *ECCV, Apr 2020* [[Paper](https://arxiv.org/abs/2004.14973)] [[Pytorch Code](https://github.com/arjunmajum/vln-bert)]


### PR DESCRIPTION
The paper builds recurrence into pre-trained large transformer-based V&L models to transform the transformer into a policy network which could be used directly use for vision-language navigation and language-guided remote object grounding. The method has been applied to a number of later works on V&L navigation and manipulation tasks.